### PR TITLE
Add access token middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -124,6 +124,8 @@ if (!config.isUaaConfigured()) {
   //   app.get('/windy/*', passport.authenticate('main', { noredirect: true}),
   //     // if calling a secure microservice, you can use this middleware to add a client token.
   //     // proxy.addClientTokenMiddleware,
+  //     // or you can use this middleware to add an access token.
+  //     // proxy.addAccessTokenMiddleware,
   //     proxy.customProxyMiddleware('/windy', windServiceURL)
   //   );
   // }

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -172,7 +172,17 @@ var addClientTokenMiddleware = function(req, res, next) {
 	}
 };
 
-router.use('/', addClientTokenMiddleware);
+router.use(['/predix-api', '/api'], addClientTokenMiddleware);
+
+// Adds authorization token from passport to request
+var addAccessTokenMiddleware = function (req, res, next) {
+	if (req.session) {
+		req.headers['Authorization'] = 'bearer ' + req.session.passport.user.ticket.access_token;
+		next();
+	} else {
+		next(res.sendStatus(403).send('Forbidden'));
+	}
+};
 
 // TODO: Support for multiple instances of the same service.
 var setProxyRoutes = function() {
@@ -217,5 +227,6 @@ module.exports = {
 	setUaaConfig: setUaaConfig,
 	customProxyMiddleware: customProxyMiddleware,
 	addClientTokenMiddleware: addClientTokenMiddleware,
+	addAccessTokenMiddleware: addAccessTokenMiddleware,
 	expressProxy: expressProxy
 };


### PR DESCRIPTION
Add access token middleware to pass the principal's access token to proxied services. Allows services to use the access token for authorization decisions, such as when using IDM group IDs added to the token scope by shared UAA.