### PR TITLE
Enable support for text and raw content in proxied requests.

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -73,6 +73,8 @@ if (config.isUaaConfigured()) {
 }
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.text());
+app.use(bodyParser.raw());
 
 /****************************************************************************
 	SET UP EXPRESS ROUTES


### PR DESCRIPTION
Unable to proxy requests with text and raw bodies without these parsers.