### PR TITLE
Use NO_PROXY environment variable (if set)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "passport": "^0.3.2",
     "passport-oauth2-middleware": "^1.0.2",
     "passport-predix-oauth": "^0.1.2",
+    "proxy-from-env": "^1.0.0",
     "ws": "^2.2.1"
   }
 }

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -10,6 +10,7 @@ var url = require('url');
 var express = require('express');
 var expressProxy = require('express-http-proxy');
 var HttpsProxyAgent = require('https-proxy-agent');
+var getProxyForUrl = require('proxy-from-env').getProxyForUrl;
 var predixConfig = require('../predix-config');
 var router = express.Router();
 var vcapServices = {};
@@ -82,7 +83,7 @@ function cleanResponseHeaders (rsp, data, req, res, cb) {
 
 function buildDecorator(zoneId) {
 	var decorator = function(req) {
-		if (corporateProxyAgent) {
+		if (corporateProxyAgent && getProxyForUrl(req.url))
 			req.agent = corporateProxyAgent;
 		}
 		req.headers['Content-Type'] = 'application/json';

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -85,7 +85,6 @@ function buildDecorator(zoneId) {
 	var decorator = function(req) {
 		if (corporateProxyAgent && getProxyForUrl(req.url))
 			req.agent = corporateProxyAgent;
-		}
 		req.headers['Content-Type'] = 'application/json';
 		if (zoneId) {
 			req.headers['Predix-Zone-Id'] = zoneId;


### PR DESCRIPTION
proxy-from-env npm module determines if a URL should be proxied by using the standard proxy environment variables (http_proxy, no_proxy etc.).  NO_PROXY tokens are supported, including wildcard expressions (i.e. .ge.com)