### PR TITLE
Use predix-uaa-client for fetching authentication tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "passport": "^0.3.2",
     "passport-oauth2-middleware": "^1.0.2",
     "passport-predix-oauth": "^0.1.2",
+    "predix-uaa-client": "^1.3.1",
     "ws": "^2.2.1"
   }
 }

--- a/server/routes/proxy.js
+++ b/server/routes/proxy.js
@@ -141,18 +141,13 @@ var addClientTokenMiddleware = function(req, res, next) {
 	// console.log('proxy root route');
 	if (req.session) {
 		// console.log('session found.');
-		if (!req.session.clientToken) {
-			// console.log('fetching client token');
-			getClientToken(function(token) {
-				req.session.clientToken = token;
-				req.headers['Authorization'] = req.session.clientToken;
-				next();
-			}, errorHandler);
-		} else {
-			// console.log('client token found in session');
-			req.headers['Authorization'] = req.session.clientToken;
+		// console.log('fetching client token');
+		// getClientToken will returned a cached token if it's not expired
+		// or renew if it has expired.
+		getClientToken(function(token) {
+			req.headers['Authorization'] = token;
 			next();
-		}
+		}, errorHandler);
 	} else {
 		next(res.sendStatus(403).send('Forbidden'));
 	}


### PR DESCRIPTION
Switch to using the predix-uaa-client for fetching client tokens used to authenticate with back-end services.  Simplifies code rather than forming the request directly.  Adds token caching and renewing capabilities automatically.